### PR TITLE
gitignore added and aux files removed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+*.aux
+*.bcf
+*.lof
+*.log
+*.lot
+*.run.xml
+*.synctex.gz
+*.toc

--- a/contents/01-Einleitung.aux
+++ b/contents/01-Einleitung.aux
@@ -72,7 +72,7 @@
 \setcounter{refsegment}{0}
 \setcounter{maxextratitle}{0}
 \setcounter{maxextratitleyear}{0}
-\setcounter{maxextraname}{2}
+\setcounter{maxextraname}{0}
 \setcounter{maxextradate}{0}
 \setcounter{maxextraalpha}{0}
 \setcounter{abbrvpenalty}{50}
@@ -164,8 +164,6 @@
 \setcounter{bbx:relatedtotal}{0}
 \setcounter{cbx@tempcnta}{0}
 \setcounter{cbx@tempcntb}{0}
-\setcounter{cbx@tempcntc}{0}
-\setcounter{cbx@tempcntd}{0}
 \setcounter{Item}{0}
 \setcounter{Hfootnote}{0}
 \setcounter{bookmark@seq@number}{0}

--- a/contents/02-StandForschungTechnik.aux
+++ b/contents/02-StandForschungTechnik.aux
@@ -58,7 +58,7 @@
 \setcounter{citetotal}{0}
 \setcounter{multicitecount}{0}
 \setcounter{multicitetotal}{0}
-\setcounter{instcount}{4}
+\setcounter{instcount}{0}
 \setcounter{maxnames}{3}
 \setcounter{minnames}{1}
 \setcounter{maxitems}{3}
@@ -72,7 +72,7 @@
 \setcounter{refsegment}{0}
 \setcounter{maxextratitle}{0}
 \setcounter{maxextratitleyear}{0}
-\setcounter{maxextraname}{2}
+\setcounter{maxextraname}{0}
 \setcounter{maxextradate}{0}
 \setcounter{maxextraalpha}{0}
 \setcounter{abbrvpenalty}{50}
@@ -163,9 +163,7 @@
 \setcounter{bbx:relatedcount}{0}
 \setcounter{bbx:relatedtotal}{0}
 \setcounter{cbx@tempcnta}{0}
-\setcounter{cbx@tempcntb}{1}
-\setcounter{cbx@tempcntc}{0}
-\setcounter{cbx@tempcntd}{-1}
+\setcounter{cbx@tempcntb}{0}
 \setcounter{Item}{0}
 \setcounter{Hfootnote}{0}
 \setcounter{bookmark@seq@number}{0}

--- a/contents/Abstract.aux
+++ b/contents/Abstract.aux
@@ -1,10 +1,10 @@
 \relax 
 \providecommand\hyper@newdestlabel[2]{}
 \babel@aux{english}{}
-\new@tpo@label{21}{27}
+\new@tpo@label{19}{23}
 \babel@aux{ngerman}{}
 \@setckpt{contents/Abstract}{
-\setcounter{page}{28}
+\setcounter{page}{24}
 \setcounter{equation}{1}
 \setcounter{enumi}{0}
 \setcounter{enumii}{0}
@@ -41,7 +41,7 @@
 \setcounter{citetotal}{0}
 \setcounter{multicitecount}{0}
 \setcounter{multicitetotal}{0}
-\setcounter{instcount}{8}
+\setcounter{instcount}{0}
 \setcounter{maxnames}{3}
 \setcounter{minnames}{1}
 \setcounter{maxitems}{3}
@@ -55,7 +55,7 @@
 \setcounter{refsegment}{0}
 \setcounter{maxextratitle}{0}
 \setcounter{maxextratitleyear}{0}
-\setcounter{maxextraname}{2}
+\setcounter{maxextraname}{0}
 \setcounter{maxextradate}{0}
 \setcounter{maxextraalpha}{0}
 \setcounter{abbrvpenalty}{50}
@@ -146,11 +146,9 @@
 \setcounter{bbx:relatedcount}{0}
 \setcounter{bbx:relatedtotal}{0}
 \setcounter{cbx@tempcnta}{0}
-\setcounter{cbx@tempcntb}{1}
-\setcounter{cbx@tempcntc}{0}
-\setcounter{cbx@tempcntd}{-1}
+\setcounter{cbx@tempcntb}{0}
 \setcounter{Item}{0}
-\setcounter{Hfootnote}{1}
+\setcounter{Hfootnote}{0}
 \setcounter{bookmark@seq@number}{0}
 \setcounter{section@level}{1}
 }

--- a/contents/Kurzfassung.aux
+++ b/contents/Kurzfassung.aux
@@ -1,7 +1,7 @@
 \relax 
 \providecommand\hyper@newdestlabel[2]{}
 \@setckpt{contents/Kurzfassung}{
-\setcounter{page}{29}
+\setcounter{page}{25}
 \setcounter{equation}{1}
 \setcounter{enumi}{0}
 \setcounter{enumii}{0}
@@ -38,7 +38,7 @@
 \setcounter{citetotal}{0}
 \setcounter{multicitecount}{0}
 \setcounter{multicitetotal}{0}
-\setcounter{instcount}{8}
+\setcounter{instcount}{0}
 \setcounter{maxnames}{3}
 \setcounter{minnames}{1}
 \setcounter{maxitems}{3}
@@ -52,7 +52,7 @@
 \setcounter{refsegment}{0}
 \setcounter{maxextratitle}{0}
 \setcounter{maxextratitleyear}{0}
-\setcounter{maxextraname}{2}
+\setcounter{maxextraname}{0}
 \setcounter{maxextradate}{0}
 \setcounter{maxextraalpha}{0}
 \setcounter{abbrvpenalty}{50}
@@ -143,11 +143,9 @@
 \setcounter{bbx:relatedcount}{0}
 \setcounter{bbx:relatedtotal}{0}
 \setcounter{cbx@tempcnta}{0}
-\setcounter{cbx@tempcntb}{1}
-\setcounter{cbx@tempcntc}{0}
-\setcounter{cbx@tempcntd}{-1}
+\setcounter{cbx@tempcntb}{0}
 \setcounter{Item}{0}
-\setcounter{Hfootnote}{1}
+\setcounter{Hfootnote}{0}
 \setcounter{bookmark@seq@number}{0}
 \setcounter{section@level}{1}
 }

--- a/contents/Nomenklatur.aux
+++ b/contents/Nomenklatur.aux
@@ -61,7 +61,7 @@
 \setcounter{refsegment}{0}
 \setcounter{maxextratitle}{0}
 \setcounter{maxextratitleyear}{0}
-\setcounter{maxextraname}{2}
+\setcounter{maxextraname}{0}
 \setcounter{maxextradate}{0}
 \setcounter{maxextraalpha}{0}
 \setcounter{abbrvpenalty}{50}
@@ -153,8 +153,6 @@
 \setcounter{bbx:relatedtotal}{0}
 \setcounter{cbx@tempcnta}{0}
 \setcounter{cbx@tempcntb}{0}
-\setcounter{cbx@tempcntc}{0}
-\setcounter{cbx@tempcntd}{0}
 \setcounter{Item}{0}
 \setcounter{Hfootnote}{0}
 \setcounter{bookmark@seq@number}{0}

--- a/contents/Vorwort.aux
+++ b/contents/Vorwort.aux
@@ -54,7 +54,7 @@
 \setcounter{refsegment}{0}
 \setcounter{maxextratitle}{0}
 \setcounter{maxextratitleyear}{0}
-\setcounter{maxextraname}{2}
+\setcounter{maxextraname}{0}
 \setcounter{maxextradate}{0}
 \setcounter{maxextraalpha}{0}
 \setcounter{abbrvpenalty}{50}
@@ -146,8 +146,6 @@
 \setcounter{bbx:relatedtotal}{0}
 \setcounter{cbx@tempcnta}{0}
 \setcounter{cbx@tempcntb}{0}
-\setcounter{cbx@tempcntc}{0}
-\setcounter{cbx@tempcntd}{0}
 \setcounter{Item}{0}
 \setcounter{Hfootnote}{0}
 \setcounter{bookmark@seq@number}{0}

--- a/contents/X+1-SummaryOutlook.aux
+++ b/contents/X+1-SummaryOutlook.aux
@@ -43,7 +43,7 @@
 \setcounter{citetotal}{0}
 \setcounter{multicitecount}{0}
 \setcounter{multicitetotal}{0}
-\setcounter{instcount}{4}
+\setcounter{instcount}{0}
 \setcounter{maxnames}{3}
 \setcounter{minnames}{1}
 \setcounter{maxitems}{3}
@@ -57,7 +57,7 @@
 \setcounter{refsegment}{0}
 \setcounter{maxextratitle}{0}
 \setcounter{maxextratitleyear}{0}
-\setcounter{maxextraname}{2}
+\setcounter{maxextraname}{0}
 \setcounter{maxextradate}{0}
 \setcounter{maxextraalpha}{0}
 \setcounter{abbrvpenalty}{50}
@@ -148,9 +148,7 @@
 \setcounter{bbx:relatedcount}{0}
 \setcounter{bbx:relatedtotal}{0}
 \setcounter{cbx@tempcnta}{0}
-\setcounter{cbx@tempcntb}{1}
-\setcounter{cbx@tempcntc}{0}
-\setcounter{cbx@tempcntd}{-1}
+\setcounter{cbx@tempcntb}{0}
 \setcounter{Item}{0}
 \setcounter{Hfootnote}{0}
 \setcounter{bookmark@seq@number}{0}

--- a/contents/X-ZusammenfassungAusblick.aux
+++ b/contents/X-ZusammenfassungAusblick.aux
@@ -41,7 +41,7 @@
 \setcounter{citetotal}{0}
 \setcounter{multicitecount}{0}
 \setcounter{multicitetotal}{0}
-\setcounter{instcount}{4}
+\setcounter{instcount}{0}
 \setcounter{maxnames}{3}
 \setcounter{minnames}{1}
 \setcounter{maxitems}{3}
@@ -55,7 +55,7 @@
 \setcounter{refsegment}{0}
 \setcounter{maxextratitle}{0}
 \setcounter{maxextratitleyear}{0}
-\setcounter{maxextraname}{2}
+\setcounter{maxextraname}{0}
 \setcounter{maxextradate}{0}
 \setcounter{maxextraalpha}{0}
 \setcounter{abbrvpenalty}{50}
@@ -146,9 +146,7 @@
 \setcounter{bbx:relatedcount}{0}
 \setcounter{bbx:relatedtotal}{0}
 \setcounter{cbx@tempcnta}{0}
-\setcounter{cbx@tempcntb}{1}
-\setcounter{cbx@tempcntc}{0}
-\setcounter{cbx@tempcntd}{-1}
+\setcounter{cbx@tempcntb}{0}
 \setcounter{Item}{0}
 \setcounter{Hfootnote}{0}
 \setcounter{bookmark@seq@number}{0}


### PR DESCRIPTION
To avoid unecessary clutter, it is a good practice to introduce a gitignore-file and to remove the aux files, as they are regenerated on every new build of the `Hauptdatei.tex`.